### PR TITLE
Update httpDL.lua

### DIFF
--- a/httpDL.lua
+++ b/httpDL.lua
@@ -39,6 +39,7 @@ function M.download(host, port, url, path, callback)
 			  "Connection: close\r\n"..
 			  "Accept-Charset: utf-8\r\n"..
 			  "Accept-Encoding: \r\n"..
+			  "User-Agent: Mozilla/4.0 (compatible; esp8266 Lua; Windows NT 5.1)\r\n".. 
 			  "Accept: */*\r\n\r\n")
 end
 return M


### PR DESCRIPTION
Added:            "User-Agent: Mozilla/4.0 (compatible; esp8266 Lua; Windows NT 5.1)\r\n".. 

Without the User-Agent, Apache servers will not execute php scripts. If using httpDL to retrieve data or post data to a script, this would be a problem.